### PR TITLE
Remove dependencies on @babel/runtime and @babel/runtime-corejs3

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,7 @@
     "jest": "^24.9.0",
     "rimraf": "^2.6.3"
   },
-  "dependencies": {
-    "@babel/runtime": "^7.7.4",
-    "@babel/runtime-corejs3": "^7.7.4"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "eslint": "^5 || ^6"
   },


### PR DESCRIPTION
These were added as dependencies in 2.1.0.

However, they don't make sense to include as dependencies because Babel only outputs code which requires them if the [runtime transform](https://babeljs.io/docs/en/babel-plugin-transform-runtime) is used. axobject-query neither uses nor depends on that transform.

Also, if a package does use the Babel runtime transform, then it generally only needs to depend on one of @babel/runtime or @babel/runtime-corejs3, but not both. (The former is usually preferred for libraries.)

I double checked by grepping the [published package](https://unpkg.com/browse/axobject-query@2.1.1/lib/) for `@babel` and found no occurrences.