### PR TITLE
Fix summary element

### DIFF
--- a/scripts/axmodel.json
+++ b/scripts/axmodel.json
@@ -386,7 +386,14 @@
   },
   "DisclosureTriangleRole": {
     "type": "widget",
-    "relatedConcepts": []
+    "relatedConcepts": [
+      {
+        "module": "HTML",
+        "concept": {
+          "name": "summary"
+        }
+      }
+    ]
   },
   "DivRole": {
     "type": "generic",

--- a/scripts/buildModelModules.js
+++ b/scripts/buildModelModules.js
@@ -113,7 +113,7 @@ fs.readFile(path.join('scripts/axmodel.json'), {
         '/**',
         ' * @flow',
         ' */',
-        `const ${camelName}:AXObjectModelDefinition = {`,
+        `const ${camelName}: AXObjectModelDefinition = {`,
         Object.keys(aria[name])
           .sort()
           .map((prop) => {

--- a/src/etc/objects/DisclosureTriangleRole.js
+++ b/src/etc/objects/DisclosureTriangleRole.js
@@ -2,7 +2,14 @@
  * @flow
  */
 const DisclosureTriangleRole: AXObjectModelDefinition = {
-  relatedConcepts: [],
+  relatedConcepts: [
+    {
+      module: 'HTML',
+      concept: {
+        name: 'summary',
+      },
+    },
+  ],
   type: 'widget',
 };
 


### PR DESCRIPTION
The `<summary>` element is mapped to the `DisclosureTriangleRole` object, which is a `widget` and interactive.

<img width="1215" alt="Screen Shot 2020-06-21 at 4 32 35 PM" src="https://user-images.githubusercontent.com/345913/85237954-75950200-b3df-11ea-8102-555c78c218f6.png">
