### PR TITLE
Remove dequal as a dep from the project.

### DIFF
--- a/flow/dequal.js
+++ b/flow/dequal.js
@@ -1,3 +1,0 @@
-declare module 'dequal/lite' {
-  declare export function dequal(foo: any, bar: any): boolean;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,9 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "axobject-query",
       "version": "4.0.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      },
       "devDependencies": {
         "@babel/cli": "^7.19.3",
         "@babel/core": "^7.19.6",
@@ -4000,14 +3998,6 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -12350,11 +12340,6 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
-    },
-    "dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "detect-newline": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,5 @@
     "ie 11"
   ],
   "dependencies": {
-    "dequal": "^2.0.3"
   }
 }

--- a/src/elementAXObjectMap.js
+++ b/src/elementAXObjectMap.js
@@ -2,7 +2,6 @@
  * @flow
  */
 
-import { dequal } from 'dequal/lite';
 import AXObjects from './AXObjectsMap';
 import iterationDecorator from './util/iterationDecorator';
 
@@ -48,6 +47,32 @@ for (let [name, def] of AXObjects.entries()) {
   }
 }
 
+function deepAxObjectModelRelationshipConceptAttributeCheck(a?: Array<AXObjectModelRelationConceptAttribute>, b?: Array<AXObjectModelRelationConceptAttribute>) {
+  if (a === undefined && b !== undefined) {
+    return false;
+  }
+
+  if (a !== undefined && b === undefined) {
+    return false;
+  }
+
+  if (a !== undefined && b !== undefined) { 
+    if (a.length != b.length) {
+      return false;
+    }
+
+    // dequal checks position equality
+    // https://github.com/lukeed/dequal/blob/5ecd990c4c055c4658c64b4bdfc170f219604eea/src/index.js#L17-L22
+    for (let i = 0; i < a.length; i++)  {
+      if (b[i].name !== a[i].name || b[i].value !== a[i].value) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 const elementAXObjectMap: TAXObjectQueryMap<
   TElementAXObjects,
   AXObjectModelRelationConcept,
@@ -66,7 +91,7 @@ const elementAXObjectMap: TAXObjectQueryMap<
   },
   get: function (key: AXObjectModelRelationConcept): ?Array<AXObjectName> {
     const item = elementAXObjects.find(tuple => (
-      key.name === tuple[0].name && dequal(key.attributes, tuple[0].attributes)
+      key.name === tuple[0].name && deepAxObjectModelRelationshipConceptAttributeCheck(key.attributes, tuple[0].attributes)
     ));
     return item && item[1];
   },


### PR DESCRIPTION
Inspection of the code and types showed that the actual check does not need to handle all cases, but rather there is a small handful of attributes and cases to check. As such do it in the project directly and remove the entire need for a dep.

Ref: https://github.com/A11yance/axobject-query/pull/354